### PR TITLE
Use bridge network with the correct default WebGUI port

### DIFF
--- a/photoprism.xml
+++ b/photoprism.xml
@@ -3,7 +3,7 @@
     <Name>PhotoPrism</Name>
     <Repository>photoprism/photoprism</Repository>
     <Registry>https://hub.docker.com/r/photoprism/photoprism</Registry>
-    <Network>host</Network>
+    <Network>bridge</Network>
     <MyIP/>
     <Shell>sh</Shell>
     <Privileged>false</Privileged>
@@ -35,7 +35,7 @@ Database lockups: If you got problems where the database lockes up you should sw
     <Config Name="Website Description" Target="PHOTOPRISM_SITE_DESCRIPTION" Default="" Mode="" Description="Website Description" Type="Variable" Display="always" Required="false" Mask="false"/>
     <Config Name="Website Author" Target="PHOTOPRISM_SITE_AUTHOR" Default="" Mode="" Description="Website Author" Type="Variable" Display="always" Required="false" Mask="false"/>
     <Config Name="Initial Admin Password" Target="PHOTOPRISM_ADMIN_PASSWORD" Default="" Mode="" Description="Initial Admin Password - you can change the password on the settings page (If you don't want to use a password delete this entry and create another variable with the Key: 'PHOTOPRISM_PUBLIC' and the Value: 'true')" Type="Variable" Display="always" Required="true" Mask="true"/>
-    <Config Name="WebGUI Port" Target="2343" Default="" Mode="tcp" Description="WebGUI Port" Type="Port" Display="always" Required="false" Mask="false">2343</Config>
+    <Config Name="WebGUI Port" Target="2342" Default="" Mode="tcp" Description="WebGUI Port" Type="Port" Display="always" Required="false" Mask="false">2342</Config>
     <Config Name="Photoprims Database Type" Target="PHOTOPRISM_DATABASE_DRIVER" Default="" Mode="" Description="Choose if you want to use the builtin 'sqlite' database or a 'mysql' based database (If you got problems where the database lockes up you should switch to mysql but you have to also setup a dedicated database for that for example 'MariaDB' from Linuxserver.io)" Type="Variable" Display="always" Required="true" Mask="false">sqlite</Config>
     <Config Name="MySQL Database Connection" Target="PHOTOPRISM_DATABASE_DSN" Default="" Mode="" Description="Needs to be filled out if you are using a 'mysql' based databyse type (it has to be filled in exact this format: 'DBUSER:DBPASSWORD@tcp(DBIP:DBPORT)/photoprism?parseTime=true' all values in CAPS have to be replaced with your credentials and without quotes)" Type="Variable" Display="always" Required="false" Mask="false"/>
     <Config Name="Webdav Autoindex - Safety Delay" Target="PHOTOPRISM_AUTO_INDEX" Default="" Mode="" Description="Set the safety delay for the Webdav Autoindexing in seconds (set to '-1' to disable set to '0' to enable the default value of 15 minutes or your preferred value in seconds)" Type="Variable" Display="always" Required="false" Mask="false">0</Config>


### PR DESCRIPTION
We can see in the Docker container logs that the Photoprism server listens on 2342:

```
time="2024-01-18T13:49:33+01:00" level=info msg="server: listening on 0.0.0.0:2342
```

With this fixed, it isn't needed to rely on the `host` network mode to bypass port forwarding.